### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/solidstate.yaml
+++ b/solidstate.yaml
@@ -1,8 +1,1 @@
 enabled: true
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/solid-state


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
